### PR TITLE
update to 1.32 and change local branch to 1.32

### DIFF
--- a/mediawiki/install.sls
+++ b/mediawiki/install.sls
@@ -31,6 +31,7 @@ mediawiki_git_{{ site }}_install:
   git.latest:
     - name: https://gerrit.wikimedia.org/r/p/mediawiki/core.git
     - rev: {{ mediawiki.git_branch }}
+    - branch: {{ mediawiki.git_branch }}
     - target: {{ mediawiki.install_dir }}/{{ site }}
 
 # Vendor install required for Mediawiki
@@ -38,5 +39,6 @@ mediawiki_git_vendor_{{ site }}_install:
   git.latest:
     - name: https://gerrit.wikimedia.org/r/mediawiki/vendor.git
     - rev: {{ mediawiki.git_branch }}
+    - branch: {{ mediawiki.git_branch }}
     - target: {{ mediawiki.install_dir }}/{{ site }}/vendor
 {% endfor %}

--- a/mediawiki/map.jinja
+++ b/mediawiki/map.jinja
@@ -1,6 +1,6 @@
 {% set mediawiki = salt['grains.filter_by']({
   'default': {
-    'version': '1.31.1',
+    'version': '1.32.0',
     'install_dir': '/var/www/html',
     'config_file': 'LocalSettings.php',
     'config_file_source': 'salt://mediawiki/templates/mediawiki.jinja',

--- a/mediawiki/plugins.sls
+++ b/mediawiki/plugins.sls
@@ -7,6 +7,7 @@
   git.latest:
     - name: https://gerrit.wikimedia.org/r/mediawiki/extensions/{{ plugin }}.git
     - rev: {{ mediawiki.git_branch }}
+    - branch: {{ mediawiki.git_branch }}
     - target: {{ mediawiki.install_dir }}/{{ site }}/extensions/{{ plugin }}
 {% endfor %}
 {% endfor %}

--- a/mediawiki/skins.sls
+++ b/mediawiki/skins.sls
@@ -7,6 +7,7 @@
   git.latest:
     - name: https://gerrit.wikimedia.org/r/mediawiki/skins/{{ skin }}.git
     - rev: {{ mediawiki.git_branch }}
+    - branch: {{ mediawiki.git_branch }}
     - target: {{ mediawiki.install_dir }}/{{ site }}/skins/{{ skin }}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
This PR moves to 1.32 branch for Mediawiki and changes the local branch to the correct branch instead of master.